### PR TITLE
Add "next" to fix next is not defined error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## vNext
 - ...
 
+## v0.24.3
+- [BE] Add missing `next` functions to prevent Stats API crash
+
 ## v0.24.2
 - [BE] Fix memory leak issue
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "PolkaStats API",
   "author": "Mario Pino Uceda",
   "license": "Apache-2.0",

--- a/api/src/services/healthService.js
+++ b/api/src/services/healthService.js
@@ -129,7 +129,7 @@ async function checkBlockchainHealth(req, res, next) {
   }
 }
 
-async function checkBlockchainBlocksFinalization(req, res) {
+async function checkBlockchainBlocksFinalization(req, res, next) {
   try {
     const { query } = req;
     let networks = splitParams(query.networks);
@@ -167,7 +167,7 @@ async function checkBlockchainBlocksFinalization(req, res) {
   }
 }
 
-async function checkBlockchainBlocksProducing(req, res) {
+async function checkBlockchainBlocksProducing(req, res, next) {
   try {
     const { query } = req;
     let networks = splitParams(query.networks);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "PolkaStats NG Backend",
   "author": "Mario Pino Uceda",
   "license": "Apache-2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "PolkaStats NG frontend",
   "author": "Mario Pino Uceda",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "cerestats",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Cere Stats mono repo",
   "repository": {
     "type": "git",


### PR DESCRIPTION
While investigating the "Unable to retrieve header and parent from supplied hash" issue found that the `next` function is missing in the API function declaration which caused the app to crash and alert in the PROD alerts channel.