### PR TITLE
Replace `extrinsic` with `event` as a data source on the SentTransfers page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Cere Stats
 
 ## vNext
-...
+- [FE] Replace `extrinsic` with `event` as a data source on the `SentTransfers` page
 
 ## v0.30.0
 - [FE] Set up GTAG GA4 Analytics, replace the `@nuxtjs/google-analytics` package with `@nuxtjs/gtm`.


### PR DESCRIPTION
Initially, we fetched data from "extrinsic" using property signer. However, it doesn't work with MultiSign transactions because the signer is not equal to the sender. 
You can check the block [10844577](https://stats.cere.network/block?blockNumber=10844577). 
The signer is [6RxK38Yiw75J8Cm2eQpU8NHvszk2SDzKX6FQxQa1Rwx3CFEh](https://stats.cere.network/account/6RxK38Yiw75J8Cm2eQpU8NHvszk2SDzKX6FQxQa1Rwx3CFEh), while the transfer was made from [6TR4e…ZgLy3](https://stats.cere.network/account/6TR4eACbYkQQ5EciS5kLjB12WHih9reBer4r4xXK12XZgLy3) to [6QLmM…68zpn](https://stats.cere.network/account/6QLmMGSvXgSvEzPGtrN4CP7r66kRVk3wmjqvMnoReYn68zpn).

Therefore, I replaced the source with extrinsics for the event, which presents data in the format `"[from, to, amount]"`. This provides information about transfers.